### PR TITLE
Fix: The histogram buffer sequence should be ARGB for vImageHistogramCalculation_ARGB8888

### DIFF
--- a/ShinpuruImage/ShinpuruImage_vImage.swift
+++ b/ShinpuruImage/ShinpuruImage_vImage.swift
@@ -46,7 +46,7 @@ extension UIImage
         let greenPtr = UnsafeMutablePointer<vImagePixelCount>(green)
         let bluePtr = UnsafeMutablePointer<vImagePixelCount>(blue)
         
-        let rgba = [redPtr, greenPtr, bluePtr, alphaPtr]
+        let rgba = [alphaPtr, redPtr, greenPtr, bluePtr]
         
         let histogram = UnsafeMutablePointer<UnsafeMutablePointer<vImagePixelCount>>(rgba)
         


### PR DESCRIPTION
The histogram buffer sequence for vImageHistogramCalculation_ARGB8888 should be ARGB.
